### PR TITLE
Patched notebook issues in Classes & Methods

### DIFF
--- a/_notebooks/CSSE/Lessons/Classes_and_Methods/2024-10-27-classes-intro.ipynb
+++ b/_notebooks/CSSE/Lessons/Classes_and_Methods/2024-10-27-classes-intro.ipynb
@@ -23,6 +23,8 @@
    },
    "outputs": [],
    "source": [
+    "// Not intended to be run, just to show the syntax\n",
+    "\n",
     "// Declaration\n",
     "class Rectangle {  \n",
     "    // The `constructor` method is a special method of a class \n",
@@ -90,6 +92,8 @@
    },
    "outputs": [],
    "source": [
+    "// Not intended to be run, just to show the syntax\n",
+    "\n",
     "class Rectangle {\n",
     "    constructor(height, width) {\n",
     "        this.height = height;\n",
@@ -111,14 +115,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {
     "vscode": {
      "languageId": "javascript"
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/javascript": "\nclass Rectangle {\n    // Constructor\n    constructor(height, width) {\n        this.height = height;\n        this.width = width;\n    }\n\n    // Getter\n    get area() {\n        return this.calcArea();\n    }\n\n    // Method\n    calcArea() {\n        return this.height * this.width;\n    }\n\n    // Generator\n    *getSides() {\n        yield this.height;\n        yield this.width;\n        yield this.height;\n        yield this.width;\n    }\n}\n\nconst square = new Rectangle(10, 10);\n\nconsole.log(square.area); // 100\nconsole.log([...square.getSides()]); // [10, 10, 10, 10]\n  \n",
+      "text/plain": [
+       "<IPython.core.display.Javascript object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
+    "%%js\n",
+    "\n",
     "class Rectangle {\n",
     "    // Constructor\n",
     "    constructor(height, width) {\n",
@@ -251,8 +268,22 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
-   "name": "python"
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
- Added  `%%js` to a few code cells in the Classes & Methods Intro notebook.
- Added comments to identify code cells not mean to be run (for syntax demonstration only).